### PR TITLE
fix(cve-report): Generate json recipe list per branch

### DIFF
--- a/scripts/cve-report.py
+++ b/scripts/cve-report.py
@@ -4,6 +4,7 @@ import os, sys
 import json
 
 jsonfile = sys.argv[1]
+outputdir = sys.argv[2]
 
 #ignored_recipes = ("linux-yocto", "db", "db-native")
 ignored_recipes = []
@@ -37,8 +38,12 @@ for cve in cves:
     else:
         recipe_counts[recipename] = 1
 
+recipe_list = dict()
 
 print("\n")
 print("Summary of CVE counts by recipes:\n")
 for recipe, count in sorted(recipe_counts.items(), key=lambda x: x[1], reverse=True):
+    recipe_list[recipe] = count
     print("  %s: %s" % (recipe, count))
+
+json.dump(recipe_list, open(outputdir + "recipe_list.json", "w"), indent="\t")


### PR DESCRIPTION
The following PR:
- creates a dictionary called`recipe_list` with CVE list by branches
- the following command is for the `master` branch. The format used is `cve-report.py jsonfile outputdir > cve-status-$BRANCH.txt`

```bash
./scripts/cve-report.py "LOCAL_PATH/yocto-metrics/cve-check/master/1709622082.json" "LOCAL_PATH/yocto-metrics/cve-check/master/" > "LOCAL_PATH/yocto-metrics/patch-status/cve-status-master.txt"
```

- Branch list is [here](https://git.yoctoproject.org/yocto-metrics/tree/cve-check)