### PR TITLE
feat(cve-report): Generate json recipe list per branch

### DIFF
--- a/scripts/cve-report.py
+++ b/scripts/cve-report.py
@@ -12,7 +12,6 @@ with open(jsonfile) as f:
     cvedata = json.load(f)
 
 cves = dict()
-recipe_counts = {}
 
 for recipe in cvedata['package']:
     if recipe['name'] in ignored_recipes:
@@ -24,21 +23,14 @@ for recipe in cvedata['package']:
             if i["id"] in cves:
                 cves[i["id"]] += ":" + recipe['name']
             else:
-                 cves[i["id"]] = recipe['name']
+                cves[i["id"]] = recipe['name']
 
-print("Found %d unpatched CVEs" % len(cves))
-for cve in sorted(cves.keys()):
-    print("%s: %s https://web.nvd.nist.gov/view/vuln/detail?vulnId=%s *" % (cve, cves[cve], cve))
+structured_data = {}
 
-for cve in cves:
-    recipename = cves[cve]
-    if recipename in recipe_counts:
-        recipe_counts[recipename] += 1
-    else:
-        recipe_counts[recipename] = 1
+for cve, name in cves.items():
+    if name not in structured_data:
+        structured_data[name] = {'count': 0, 'cves': []}
+    structured_data[name]['count'] += 1
+    structured_data[name]['cves'].append('https://web.nvd.nist.gov/view/vuln/detail?vulnId=%s' % cve)
 
-
-print("\n")
-print("Summary of CVE counts by recipes:\n")
-for recipe, count in sorted(recipe_counts.items(), key=lambda x: x[1], reverse=True):
-    print("  %s: %s" % (recipe, count))
+print(json.dumps(structured_data, indent="\t"))

--- a/scripts/run-cvecheck
+++ b/scripts/run-cvecheck
@@ -92,7 +92,7 @@ if [ -e tmp/log/cve/cve-summary.json ]; then
     if [ "$PUSH" = "1" ]; then
         git -C $METRICSDIR push
     fi
-    $OURDIR/cve-report.py tmp/log/cve/cve-summary.json > $RESULTSDIR/cve-status-$BRANCH.txt
+    $OURDIR/cve-report.py tmp/log/cve/cve-summary.json > $RESULTSDIR/cve-status-$BRANCH.json
 fi
 
 if [ "$BRANCH" = "master" ]; then


### PR DESCRIPTION
The following PR:
- creates `cve-status-branch.json` files instead of `.txt`
- This json file includes the name and count of the current CVE's of the branch. (The summary section)

- the following command is for the `master` branch. The format used is `cve-report.py jsonfile outputdir > cve-status-$BRANCH.txt`

```bash
./scripts/cve-report.py "LOCAL_PATH/yocto-metrics/cve-check/master/1709622082.json" "LOCAL_PATH/yocto-metrics/cve-check/master/" > "LOCAL_PATH/yocto-metrics/patch-status/cve-status-master.json"
```

- Branch list is [here](https://git.yoctoproject.org/yocto-metrics/tree/cve-check)


Output is

```
...
"bluez5": {
	"count": 2,
	"cves": [
		"https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-3563",
		"https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-3637"
	]
},
"busybox": {
	"count": 4,
	"cves": [
		"https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-42363",
		"https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-42364",
		"https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-42365",
		"https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-42366"
	]
},
...
}
```